### PR TITLE
Add "--recurse-submodules" option to all git clones.

### DIFF
--- a/share/po-common
+++ b/share/po-common
@@ -697,9 +697,9 @@ getLib() # "$i" "$LIB_NAME"
             GIT_ARGS=( $1 )
 
             if [ "${GIT_ARGS[1]}" == "" ]; then
-                git clone "${GIT_ARGS[0]}" || ( echo ; red_echo "Could not download Library. Please supply a valid URL to a git repository." )
+                git clone --recurse-submodules "${GIT_ARGS[0]}" || ( echo ; red_echo "Could not download Library. Please supply a valid URL to a git repository." )
             else
-                git clone "${GIT_ARGS[0]}" "${GIT_ARGS[1]}" || ( echo ; red_echo "Could not download Library. Please supply a valid URL to a git repository." )
+                git clone --recurse-submodules "${GIT_ARGS[0]}" "${GIT_ARGS[1]}" || ( echo ; red_echo "Could not download Library. Please supply a valid URL to a git repository." )
             fi
         else
             echo
@@ -712,7 +712,7 @@ getLib() # "$i" "$LIB_NAME"
                 if [ "$answer" == "yes" ] || [ "$answer" == "y" ] || [ "$answer" == "Y" ]; then
                     echo
                     cd "$LIBRARY" || exit
-                    git clone "$LIBURL" "$LIB_QUERY"
+                    git clone --recurse-submodules "$LIBURL" "$LIB_QUERY"
                     echo
                     blue_echo "Downloaded $LIB_QUERY from GitHub."
                     return 0

--- a/share/po-docker
+++ b/share/po-docker
@@ -84,7 +84,7 @@ _install()
         NOGIT="false"
         echo
         blue_echo "Installing Particle firmware from Github..."
-        git clone https://github.com/particle-iot/firmware.git || ( cd firmware && git stash && git pull )
+        git clone --recurse-submodules https://github.com/particle-iot/firmware.git || ( cd firmware && git stash && git pull )
     else
         NOGIT="true"
     fi
@@ -96,7 +96,7 @@ _install()
         NOGIT="false"
         echo
         blue_echo "Installing RedBear Duo firmware from Github..."
-        git clone https://github.com/redbear/firmware.git || ( cd firmware && git stash && git pull )
+        git clone --recurse-submodules https://github.com/redbear/firmware.git || ( cd firmware && git stash && git pull )
     else
         NOGIT="true"
     fi
@@ -108,7 +108,7 @@ _install()
         NOGIT="false"
         echo
         blue_echo "Installing Particle-Pi firmware from Github..."
-        git clone https://github.com/particle-iot/firmware.git || ( cd firmware && git stash && git pull )
+        git clone --recurse-submodules https://github.com/particle-iot/firmware.git || ( cd firmware && git stash && git pull )
     else
         NOGIT="true"
     fi
@@ -187,7 +187,7 @@ _install()
         # Install dfu-util
         blue_echo "Installing dfu-util..."
         cd "$BASE_DIR" || exit
-        git clone https://github.com/nrobinson2000/dfu-util
+        git clone --recurse-submodules https://github.com/nrobinson2000/dfu-util
         cd dfu-util || exit
         git pull
         ./autogen.sh
@@ -238,20 +238,20 @@ _install()
         cd "$FIRMWARE_PARTICLE" || exit
         echo
         blue_echo "Installing Particle firmware from Github..."
-        git clone https://github.com/particle-iot/firmware.git || ( cd firmware && git stash && git pull )
+        git clone --recurse-submodules https://github.com/particle-iot/firmware.git || ( cd firmware && git stash && git pull )
 
         # clone RedBear DUO firmware repository
         cd "$FIRMWARE_DUO" || exit
         echo
         blue_echo "Installing RedBear Duo firmware from Github..."
-        git clone https://github.com/redbear/firmware.git || ( cd firmware && git stash && git pull )
+        git clone --recurse-submodules https://github.com/redbear/firmware.git || ( cd firmware && git stash && git pull )
 
 
         # clone Particle-Pi firmware repository
         cd "$FIRMWARE_PI" || exit
         echo
         blue_echo "Installing Particle-Pi firmware from Github..."
-        git clone https://github.com/particle-iot/firmware.git || ( cd firmware && git stash && git pull )
+        git clone --recurse-submodules https://github.com/particle-iot/firmware.git || ( cd firmware && git stash && git pull )
     fi
 
     green_echo "

--- a/share/po-linux
+++ b/share/po-linux
@@ -99,7 +99,7 @@ _install()
         NOGIT="false"
         echo
         blue_echo "Installing Particle firmware from Github..."
-        git clone "$PARTICLE_FIRMWARE_URL" "firmware" || ( cd firmware && git stash &> /dev/null && git fetch )
+        git clone --recurse-submodules "$PARTICLE_FIRMWARE_URL" "firmware" || ( cd firmware && git stash &> /dev/null && git fetch )
     else
         NOGIT="true"
     fi
@@ -111,7 +111,7 @@ _install()
         NOGIT="false"
         echo
         blue_echo "Installing RedBear Duo firmware from Github..."
-        git clone https://github.com/redbear/firmware.git || ( cd firmware && git stash &> /dev/null && git fetch )
+        git clone --recurse-submodules https://github.com/redbear/firmware.git || ( cd firmware && git stash &> /dev/null && git fetch )
     else
         NOGIT="true"
     fi
@@ -123,7 +123,7 @@ _install()
         NOGIT="false"
         echo
         blue_echo "Installing Particle-Pi firmware from Github..."
-        git clone https://github.com/particle-iot/firmware.git || ( cd firmware && git stash &> /dev/null && git fetch )
+        git clone --recurse-submodules https://github.com/particle-iot/firmware.git || ( cd firmware && git stash &> /dev/null && git fetch )
     else
         NOGIT="true"
     fi
@@ -210,7 +210,7 @@ _install()
         # Install dfu-util
         blue_echo "Installing dfu-util (requires sudo)..."
         cd "$BASE_DIR" || exit
-        git clone https://github.com/nrobinson2000/dfu-util
+        git clone --recurse-submodules https://github.com/nrobinson2000/dfu-util
         cd dfu-util || exit
         git fetch
         ./autogen.sh
@@ -268,20 +268,20 @@ _install()
         cd "$FIRMWARE_PARTICLE" || exit
         echo
         blue_echo "Installing Particle firmware from Github..."
-        git clone "$PARTICLE_FIRMWARE_URL" "firmware" || ( cd firmware && git stash &> /dev/null && git fetch )
+        git clone --recurse-submodules "$PARTICLE_FIRMWARE_URL" "firmware" || ( cd firmware && git stash &> /dev/null && git fetch )
 
         # clone RedBear DUO firmware repository
         cd "$FIRMWARE_DUO" || exit
         echo
         blue_echo "Installing RedBear Duo firmware from Github..."
-        git clone https://github.com/redbear/firmware.git || ( cd firmware && git stash &> /dev/null && git fetch )
+        git clone --recurse-submodules https://github.com/redbear/firmware.git || ( cd firmware && git stash &> /dev/null && git fetch )
 
 
         # clone Particle-Pi firmware repository
         cd "$FIRMWARE_PI" || exit
         echo
         blue_echo "Installing Particle-Pi firmware from Github..."
-        git clone https://github.com/particle-iot/firmware.git || ( cd firmware && git stash &> /dev/null && git fetch )
+        git clone --recurse-submodules https://github.com/particle-iot/firmware.git || ( cd firmware && git stash &> /dev/null && git fetch )
     fi
 
     green_echo "

--- a/share/po-mac
+++ b/share/po-mac
@@ -71,19 +71,19 @@ _install()
     cd "$FIRMWARE_PARTICLE" || exit
     echo
     blue_echo "Installing Particle firmware from Github..."
-    git clone "$PARTICLE_FIRMWARE_URL" "firmware" || ( cd firmware && git stash &> /dev/null && git fetch )
+    git clone --recurse-submodules "$PARTICLE_FIRMWARE_URL" "firmware" || ( cd firmware && git stash &> /dev/null && git fetch )
 
     # clone RedBear DUO firmware repository
     cd "$FIRMWARE_DUO" || exit
     echo
     blue_echo "Installing RedBear Duo firmware from Github..."
-    git clone https://github.com/redbear/firmware.git || ( cd firmware && git stash &> /dev/null && git fetch )
+    git clone --recurse-submodules https://github.com/redbear/firmware.git || ( cd firmware && git stash &> /dev/null && git fetch )
 
     # clone Particle-Pi firmware repository
     cd "$FIRMWARE_PI" || exit
     echo
     blue_echo "Installing Particle-Pi firmware from Github..."
-    git clone https://github.com/particle-iot/firmware.git || ( cd firmware && git stash &> /dev/null && git fetch )
+    git clone --recurse-submodules https://github.com/particle-iot/firmware.git || ( cd firmware && git stash &> /dev/null && git fetch )
 
     echo
 


### PR DESCRIPTION
Without this - at least on a Mac and with the Particle firmware - the builds
fail due to missing sources and headers.