### PR TITLE
Use most recent node version

### DIFF
--- a/share/po-docker
+++ b/share/po-docker
@@ -154,7 +154,7 @@ _install()
             blue_echo "Node.js version $NODEVERSION is already installed."
         else
             # MESSAGE="Installing Node.js version $NODEVERSION..." ; blue_echo
-            curl -Ss https://api.github.com/repos/nodesource/distributions/contents/"$DISTRO" | grep "name"  | grep "setup_"| grep -v "setup_iojs"| grep -v "setup_dev" > node-files.txt
+            curl -Ss https://api.github.com/repos/nodesource/distributions/contents/"$DISTRO" | grep "name" | grep "setup_" | grep -v "setup_iojs" | grep -v "setup_dev" | sort --field-separator="_" --key=2 --human-numeric-sort > node-files.txt
             tail -1 node-files.txt > node-oneline.txt
             sed -n 's/.*\"\(.*.\)\".*/\1/p' node-oneline.txt > node-version.txt
 

--- a/share/po-linux
+++ b/share/po-linux
@@ -170,7 +170,7 @@ _install()
         if [ "$(hash node &> /dev/null && node -v)" == "$NODEVERSION" ]; then
             blue_echo "Node.js version $NODEVERSION is already installed."
         else
-            curl -Ss https://api.github.com/repos/nodesource/distributions/contents/"$DISTRO" | grep "name"  | grep "setup_"| grep -v "setup_iojs"| grep -v "setup_dev" > node-files.txt
+            curl -Ss https://api.github.com/repos/nodesource/distributions/contents/"$DISTRO" | grep "name" | grep "setup_" | grep -v "setup_iojs" | grep -v "setup_dev" | sort --field-separator="_" --key=2 --human-numeric-sort > node-files.txt
             tail -1 node-files.txt > node-oneline.txt
             sed -n 's/.*\"\(.*.\)\".*/\1/p' node-oneline.txt > node-version.txt
 


### PR DESCRIPTION
This merge request fixes #19, it sorts the node versions by their version as a number rather than their whole name as a string